### PR TITLE
fixed another typo in the Bitcoin paper

### DIFF
--- a/sni/templates/docs/bitcoin.html
+++ b/sni/templates/docs/bitcoin.html
@@ -129,7 +129,7 @@
 			</ol>
 
 			<p>
-				Nodes always consider the longest chain to be the correct one and will keep working on extending it. If two nodes broadcast different versions of the next block simultaneously, some nodes may receive one or the other first. In that case, they work on the first one they received, but save the other branch in case it becomes longer. The tie will be broken when the next proof- of-work is found and one branch becomes longer; the nodes that were working on the other branch will then switch to the longer one.
+				Nodes always consider the longest chain to be the correct one and will keep working on extending it. If two nodes broadcast different versions of the next block simultaneously, some nodes may receive one or the other first. In that case, they work on the first one they received, but save the other branch in case it becomes longer. The tie will be broken when the next proof-of-work is found and one branch becomes longer; the nodes that were working on the other branch will then switch to the longer one.
 			</p>
 			
 			<p>


### PR DESCRIPTION
Hi, I've stumbled upon another typo in the transcribed Bitcoin paper while proofreading the text for our ePub & MOBI version of the paper from Liberty's Legacy Edition: "Bitcoin: A Peer-to-Peer Electronic Cash System". No rights reserved. Happy reading, sharing, editing and selling!

[Bitcoin: A Peer-to-Peer Electronic Cash System](http://www.readliberty.org/books/bitcoin-a-peer-to-peer-electronic-cash-system)
