### PR TITLE
Fix typo on crash-course.html

### DIFF
--- a/sni/templates/crash-course.html
+++ b/sni/templates/crash-course.html
@@ -47,7 +47,7 @@ Volatility currently exists, but so what? If anything, that's a good thing. Hoar
 
 * ["I Love Bitcoin's Volatility"](http://nakamotoinstitute.org/mempool/i-love-bitcoins-volatility/) by Daniel Krawisz
 
-Despite people's worries, Bitcoin does not suffer an image problem because of potential illicit usage. In fact, it's ability to bypass legal restrictions is one of its biggest selling points and should be celebrated.
+Despite people's worries, Bitcoin does not suffer an image problem because of potential illicit usage. In fact, its ability to bypass legal restrictions is one of its biggest selling points and should be celebrated.
 
 * ["Bitcoin Has No Image Problem"](http://nakamotoinstitute.org/mempool/bitcoin-has-no-image-problem/) by Daniel Krawisz
 * ["How to Market Bitcoin"](http://nakamotoinstitute.org/mempool/how-to-market-bitcoin/) by Daniel Krawisz


### PR DESCRIPTION
Just fixing an its/it's typo...

![image](https://cloud.githubusercontent.com/assets/4072974/8645381/d3d7f206-28fb-11e5-8975-73ba38fb91ba.png)
