### PR TITLE
Fix broken links under Literature and Research

### DIFF
--- a/data/literature.json
+++ b/data/literature.json
@@ -542,8 +542,7 @@
         "slug": "online-cash-checks",
         "formats": ["html", "ext"],
         "categories": ["cryptography"],
-        "doctype": "essay",
-        "external": "http://www.chaum.com/articles/Online_Cash_Checks.htm"
+        "doctype": "essay"
     },
     {
         "id": 54,

--- a/data/literature.json
+++ b/data/literature.json
@@ -542,7 +542,8 @@
         "slug": "online-cash-checks",
         "formats": ["html", "ext"],
         "categories": ["cryptography"],
-        "doctype": "essay"
+        "doctype": "essay",
+        "external": "http://www.chaum.com/publications/Online_Cash_Checks.html"
     },
     {
         "id": 54,

--- a/data/research.json
+++ b/data/research.json
@@ -54,7 +54,7 @@
         "formats": ["pdf", "ext"],
         "categories": ["cryptography"],
         "doctype": "essay",
-        "external": "http://tr.eecs.ucf.edu/78/"
+        "external": "https://socrates1024.s3.amazonaws.com/consensus.pdf"
     },
     {
         "id": 6,


### PR DESCRIPTION
Ran the site through a broken link checker.  These two 404s are on top-level pages.  There are many others, especially within individual articles.  Will get to those later.