### PR TITLE
Translated articles should have the translated title in the <title> tag

### DIFF
--- a/sni/templates/blogpost-md.html
+++ b/sni/templates/blogpost-md.html
@@ -1,5 +1,10 @@
 <!-- extend base layout -->
 {% extends "blogpost.html" %}
+
+{% block title %}
+{{ page.meta.translated_title or bp.title }} | Satoshi Nakamoto Institute
+{% endblock %}
+
 {% import "helpers.html" as helpers %}
 {% block post %}
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">


### PR DESCRIPTION
Resolves #169 