### PR TITLE
Fix typo in error page

### DIFF
--- a/sni/templates/500.html
+++ b/sni/templates/500.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
 
-<h1>An unexpected error has occurred'</h1>
+<h1>An unexpected error has occurred</h1>
 <p><a href="{{url_for('index')}}">Home</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
Very trivial fix, I noticed this because at the time of writing the /quotes/ page and any /quotes/category/ page is throwing a 500 error code.