### PR TITLE
Update secure-property-titles.html

### DIFF
--- a/sni/templates/docs/secure-property-titles.html
+++ b/sni/templates/docs/secure-property-titles.html
@@ -157,7 +157,7 @@
   </li>
 
   <li id="fn6">
-    <p>Malkhi &amp; Reiter, <a href="http://www.research.att.com/~dalia/">"Byzantine Quorum Systems"</a>, STOC97&nbsp;<a href="#ref6-1">↩</a>&nbsp;<a href="#ref6-2">↩</a></p>
+    <p>Malkhi &amp; Reiter, <a href="https://www.cs.unc.edu/~reiter/papers/1997/PODC1.pdf">"Byzantine Quorum Systems"</a>, STOC97&nbsp;<a href="#ref6-1">↩</a>&nbsp;<a href="#ref6-2">↩</a></p>
   </li>
 </ol>
 


### PR DESCRIPTION
http://www.research.att.com/~dalia/ redirects to https://about.att.com/error.html

https://www.cs.unc.edu/~reiter/papers/1997/PODC1.pdf seems to be the paper cited by Nick Szabo