### PR TITLE
satoshiindex: Improve typography of headings

### DIFF
--- a/sni/templates/satoshiindex.html
+++ b/sni/templates/satoshiindex.html
@@ -7,13 +7,13 @@ The Complete Satoshi | Satoshi Nakamoto Institute
 
 {% block content %}
 <div class="container text-center">
-  <div>
-    <h1>The Complete Satoshi</h1>
-    <p>Between 2008 and 2012, a pseudonymous programmer (or programmers) going by the name Satoshi Nakamoto shared with the world a brilliant vision and the code to build it.</p>
-    <p>Read the original whitepaper, <a href="{{url_for('slugview', slug='bitcoin')}}">"Bitcoin: A Peer-to-Peer Electronic Cash System"</a>.</p>
-    <p>PDF available in <a href="{{url_for('static', filename='docs/bitcoin.pdf')}}">English</a>, <a href="{{url_for('static', filename='docs/bitcoin-zh-cn.pdf')}}">Chinese (Simplified)</a>, <a href="{{url_for('static', filename='docs/bitcoin-zh-tw.pdf')}}">Chinese (Traditional)</a>, <a href="{{url_for('static', filename='docs/bitcoin-he.pdf')}}">Hebrew</a>, <a href="{{url_for('static', filename='docs/bitcoin-it.pdf')}}">Italian</a>, <a href="{{url_for('static', filename='docs/bitcoin-jp.pdf')}}">Japanese</a>, <a href="{{url_for('static', filename='docs/bitcoin-ru.pdf')}}">Russian</a>, <a href="{{url_for('static', filename='docs/bitcoin-es.pdf')}}">Spanish</a>, and <a href="{{url_for('static', filename='docs/bitcoin-vn.pdf')}}">Vietnamese</a></p>
-    <p><a href="{{url_for('static', filename='satoshinakamoto.asc')}}">Satoshi Nakamoto's PGP Key</a></p>
-  </div>
+  <h1>The Complete Satoshi</h1>
+  <p>Between 2008 and 2012, a pseudonymous programmer (or programmers) going by the name Satoshi Nakamoto shared with the world a brilliant vision and the code to build it.</p>
+  <hr>
+  <p>Read the original whitepaper, <a href="{{url_for('slugview', slug='bitcoin')}}">"Bitcoin: A Peer-to-Peer Electronic Cash System"</a>.</p>
+  <p>PDF available in <a href="{{url_for('static', filename='docs/bitcoin.pdf')}}">English</a>, <a href="{{url_for('static', filename='docs/bitcoin-zh-cn.pdf')}}">Chinese (Simplified)</a>, <a href="{{url_for('static', filename='docs/bitcoin-zh-tw.pdf')}}">Chinese (Traditional)</a>, <a href="{{url_for('static', filename='docs/bitcoin-he.pdf')}}">Hebrew</a>, <a href="{{url_for('static', filename='docs/bitcoin-it.pdf')}}">Italian</a>, <a href="{{url_for('static', filename='docs/bitcoin-jp.pdf')}}">Japanese</a>, <a href="{{url_for('static', filename='docs/bitcoin-ru.pdf')}}">Russian</a>, <a href="{{url_for('static', filename='docs/bitcoin-es.pdf')}}">Spanish</a>, and <a href="{{url_for('static', filename='docs/bitcoin-vn.pdf')}}">Vietnamese</a></p>
+  <p><a href="{{url_for('static', filename='satoshinakamoto.asc')}}">Satoshi Nakamoto's PGP Key</a></p>
+  <hr>
   <div class="mt-4">
     <h5><a href="{{url_for('emails')}}">Emails</a></h5>
     <p>It all began here.</p>

--- a/sni/templates/satoshiindex.html
+++ b/sni/templates/satoshiindex.html
@@ -15,19 +15,19 @@ The Complete Satoshi | Satoshi Nakamoto Institute
     <p><a href="{{url_for('static', filename='satoshinakamoto.asc')}}">Satoshi Nakamoto's PGP Key</a></p>
   </div>
   <div class="mt-4">
-    <h3><a href="{{url_for('emails')}}">Emails</a></h3>
+    <h5><a href="{{url_for('emails')}}">Emails</a></h5>
     <p>It all began here.</p>
   </div>
   <div class="mt-4">
-    <h3><a href="{{url_for('posts')}}">Forum Posts</a></h3>
+    <h5><a href="{{url_for('posts')}}">Forum Posts</a></h5>
     <p>Where an idea flourished.</p>
   </div>
   <div class="mt-4">
-    <h3><a href="{{url_for('code')}}">Code<a/></h3>
+    <h5><a href="{{url_for('code')}}">Code<a/></h5>
     <p>The vision distilled.</p>
   </div>
   <div class="mt-4">
-    <h3><a href="{{url_for('quotes')}}">Quotes</a></h3>
+    <h5><a href="{{url_for('quotes')}}">Quotes</a></h5>
     <p>Indexed wisdom from the quotable Satoshi.</p>
   </div>
 </div>


### PR DESCRIPTION
When browsing [The Complete Satoshi](https://satoshi.nakamotoinstitute.org/), the font size of the headings seemed a bit disproportionate, potentially distracting a reader from the first bit of introductory text on the page.

In case welcome, this PR changes `<h5>` to `<h3>`, to hopefully make the typography more proportionate.

**Before (`<h3>`):**

![image](https://user-images.githubusercontent.com/1130872/71780998-e67b6580-2fc9-11ea-8589-8485fdad401f.png)

**After (`<h5>`):**

![image](https://user-images.githubusercontent.com/1130872/71781015-10cd2300-2fca-11ea-884a-0fb8831a1aec.png)
