### PR TITLE
Fix markdown list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ translation_publication_url: # URL of original publication hosting translation (
 }
 ```
 Note: the name must match that in `translators.json` exactly.
+
 5. If you are submitting a new language, add it to `data/languages.json`.
 
 ## How You Can Help


### PR DESCRIPTION
The 5th step in the "Adding Mempool Transations" list was shown inline, as just another sentence in Step 4's note.

Added an extra newline above Step 5 to make sure it's shown as a standalone item in the list.