### PR TITLE
Fixed typo publication date Menger

### DIFF
--- a/data/literature.json
+++ b/data/literature.json
@@ -1553,7 +1553,7 @@
     "author": [
       "carl-menger"
     ],
-    "date": "1982",
+    "date": "1892",
     "slug": "on-the-origins-of-money",
     "formats": [
       "pdf",


### PR DESCRIPTION
"On the Origins of Money" was published in 1892: https://mises.org/library/origins-money-0